### PR TITLE
Allow changing config when run in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     depends_on:
       - mongo
     restart: always
+    volumes:
+      - ./config:/data/config
   speedlogger-runner:
     image: brennentsmith/internet-speed-logger
     depends_on:
@@ -16,6 +18,8 @@ services:
       - node
       - run-speedtest.js
       - daemon
+    volumes:
+      - ./config:/data/config
   mongo:
     image: bitnami/mongodb
     expose:


### PR DESCRIPTION
When run with docker-compose, changes to the config don't apply in the docker container. This allows those changes to be seen inside the docker container