### PR TITLE
Added chown command to the container instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ docker-compose up
 ```
 Wait a couple minutes for MongoDB to initialize, and then go to `http://localhost:3000` in your browser, and away you go!
 
-In case you see errors from mongodb with:
-mongodb | mkdir: cannot create directory '/bitnami/mongodb': Permission denied
-mongodb exited with code 1
+In case you see errors from mongodb with:<br />
+`mongodb | mkdir: cannot create directory '/bitnami/mongodb': Permission denied`<br />
+`mongodb exited with code 1`
 
 Try to set the persistent data directory rights:
 ```
@@ -71,9 +71,9 @@ git clone https://github.com/brennentsmith/internet-speed-logger.git
 cd internet-speed-logger
 docker compose up
 ```
-In case you see errors from mongodb with 
-mongodb | mkdir: cannot create directory '/bitnami/mongodb': Permission denied
-mongodb exited with code 1
+In case you see errors from mongodb with:<br />
+`mongodb | mkdir: cannot create directory '/bitnami/mongodb': Permission denied`<br />
+`mongodb exited with code 1`
 
 Try to set the persistent data directory rights:
 ```

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ cd internet-speed-logger
 docker-compose up
 ```
 Wait a couple minutes for MongoDB to initialize, and then go to `http://localhost:3000` in your browser, and away you go!
-In case you see errors from mongodb with 
+
+In case you see errors from mongodb with:
 mongodb | mkdir: cannot create directory '/bitnami/mongodb': Permission denied
 mongodb exited with code 1
+
 Try to set the persistent data directory rights:
 ```
 docker-compose down
@@ -72,6 +74,7 @@ docker compose up
 In case you see errors from mongodb with 
 mongodb | mkdir: cannot create directory '/bitnami/mongodb': Permission denied
 mongodb exited with code 1
+
 Try to set the persistent data directory rights:
 ```
 docker-compose down

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To bring it online, simply run:
 ```
 git clone https://github.com/brennentsmith/internet-speed-logger.git
 cd internet-speed-logger
+sudo chown -R 1001 mongo-persistence/
 docker-compose up
 ```
 Wait a couple minutes for MongoDB to initialize, and then go to `http://localhost:3000` in your browser, and away you go!
@@ -50,6 +51,7 @@ A container is published to [Dockerhub](https://hub.docker.com/r/brennentsmith/i
 ```
 git clone https://github.com/brennentsmith/internet-speed-logger.git
 cd internet-speed-logger
+sudo chown -R 1001 mongo-persistence/
 docker compose up
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@ To bring it online, simply run:
 ```
 git clone https://github.com/brennentsmith/internet-speed-logger.git
 cd internet-speed-logger
-sudo chown -R 1001 mongo-persistence/
 docker-compose up
 ```
 Wait a couple minutes for MongoDB to initialize, and then go to `http://localhost:3000` in your browser, and away you go!
+In case you see errors from mongodb with 
+mongodb | mkdir: cannot create directory '/bitnami/mongodb': Permission denied
+mongodb exited with code 1
+Try to set the persistent data directory rights:
+```
+docker-compose down
+sudo chown -R 1001 mongo-persistence/
+docker-compose up
+```
 
 ## Updating
 To get the latest Docker image, run:
@@ -59,8 +67,16 @@ A container is published to [Dockerhub](https://hub.docker.com/r/brennentsmith/i
 ```
 git clone https://github.com/brennentsmith/internet-speed-logger.git
 cd internet-speed-logger
-sudo chown -R 1001 mongo-persistence/
 docker compose up
+```
+In case you see errors from mongodb with 
+mongodb | mkdir: cannot create directory '/bitnami/mongodb': Permission denied
+mongodb exited with code 1
+Try to set the persistent data directory rights:
+```
+docker-compose down
+sudo chown -R 1001 mongo-persistence/
+docker-compose up
 ```
 
 You may see some errors upon boot regarding `speedlogger-web_1     | MongoNetworkError: failed to connect to server` - these are normal as the web service will attempt to create the connection pool before MongoDB is ready. Once MongoDB is ready (~30s), all will work correctly. 


### PR DESCRIPTION
I added a chown command to the container run instructions as the bitnami/mongodb container needs it to run, as it was mentioned in : https://github.com/brennentsmith/internet-speed-logger/issues/15
Also here in the official issues: https://github.com/bitnami/bitnami-docker-mongodb/issues/177